### PR TITLE
Add ability to hold keys without releasing them in between presses

### DIFF
--- a/purple/action.py
+++ b/purple/action.py
@@ -19,6 +19,13 @@ class Lock:
     def run(self, core, action, hold):
         core.toggle_lock(self._keycodes)
 
+class Hold:
+    def __init__(self, *keycodes):
+        self._keycodes = keycodes
+
+    def run(self, core, action, hold):
+        core.toggle_hold(self._keycodes)
+
 
 class MediaPress:
     def __init__(self, consumer_control_code):


### PR DESCRIPTION
see defiant00/purple#3

This is a best-effort attempt at a PR for #3 
– buffer for the pressed keys (so that we don't have to rely on `Keyboard.release_all()` which would affect the held keys)
- a separate buffer for held keys
- a `Hold` action that will use this new core functionality
